### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/src/xml_streamer.py
+++ b/src/xml_streamer.py
@@ -194,7 +194,7 @@ class XmlStreamer(object):
 
 def test_xml_streamer():
     def outcb(text):
-        if text == None:
+        if text is None:
             sys.stdout.write('\n\n\nAll done!\n')
         else:
             sys.stdout.write(text)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:lyx2rfc?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:lyx2rfc?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
